### PR TITLE
Add dependency script for Red Hat based distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For Arch Linux or Manjaro, run: `./install-arch-deps.sh`
 
 For openSUSE, run: `./install-opensuse-deps.sh`
 
-For Fedora, run `./install-fedora-deps.sh`
+For Fedora, CentOS, or RHEL, run `./install-redhat-deps.sh`
 
 Then, compile the source code and install the applet:
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ For Arch Linux or Manjaro, run: `./install-arch-deps.sh`
 
 For openSUSE, run: `./install-opensuse-deps.sh`
 
+For Fedora, run `./install-fedora-deps.sh
+
 Then, compile the source code and install the applet:
 
 ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For Arch Linux or Manjaro, run: `./install-arch-deps.sh`
 
 For openSUSE, run: `./install-opensuse-deps.sh`
 
-For Fedora, run `./install-fedora-deps.sh
+For Fedora, run `./install-fedora-deps.sh`
 
 Then, compile the source code and install the applet:
 

--- a/install-fedora-deps.sh
+++ b/install-fedora-deps.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-sudo dnf install cmake extra-cmake-modules gcc-c++ qt5-qtbase-devel qt5-qtdeclarative-devel qt5-qtx11extras-devel kf5-plasma-devel kf5-kglobalaccel-devel kf5-kxmlgui-devel

--- a/install-fedora-deps.sh
+++ b/install-fedora-deps.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+sudo dnf install cmake extra-cmake-modules gcc-c++ qt5-qtbase-devel qt5-qtdeclarative-devel qt5-qtx11extras-devel kf5-plasma-devel kf5-kglobalaccel-devel kf5-kxmlgui-devel

--- a/install-redhat-deps.sh
+++ b/install-redhat-deps.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+if ! dnf >/dev/null 2>&1 ; then 
+  echo "Using dnf" && dnf install cmake extra-cmake-modules gcc-c++ qt5-qtbase-devel qt5-qtdeclarative-devel qt5-qtx11extras-devel kf5-plasma-devel kf5-kglobalaccel-devel kf5-kxmlgui-devel ;
+else 
+   echo "Using yum" && yum install cmake extra-cmake-modules gcc-c++ qt5-qtbase-devel qt5-qtdeclarative-devel qt5-qtx11extras-devel kf5-plasma-devel kf5-kglobalaccel-devel kf5-kxmlgui-devel ;
+fi

--- a/install-redhat-deps.sh
+++ b/install-redhat-deps.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
-if ! dnf >/dev/null 2>&1 ; then 
-  echo "Using dnf" && dnf install cmake extra-cmake-modules gcc-c++ qt5-qtbase-devel qt5-qtdeclarative-devel qt5-qtx11extras-devel kf5-plasma-devel kf5-kglobalaccel-devel kf5-kxmlgui-devel ;
+BUILDDEPS='cmake extra-cmake-modules gcc-c++ qt5-qtbase-devel qt5-qtdeclarative-devel qt5-qtx11extras-devel kf5-plasma-devel kf5-kglobalaccel-devel kf5-kxmlgui-devel'
+if dnf >/dev/null 2>&1 ; then 
+  echo "Using dnf" && dnf install $BUILDDEPS;
 else 
-   echo "Using yum" && yum install cmake extra-cmake-modules gcc-c++ qt5-qtbase-devel qt5-qtdeclarative-devel qt5-qtx11extras-devel kf5-plasma-devel kf5-kglobalaccel-devel kf5-kxmlgui-devel ;
+   echo "Using yum" && yum install $BUILDDEPS;
 fi


### PR DESCRIPTION
as the title says, this pr adds a very small script that Fedora users can run to install the needed dependencies to build the widget and fixes the readme to include Fedora