### PR TITLE
Fix dependency (make)

### DIFF
--- a/scripts/install-dependencies-arch.sh
+++ b/scripts/install-dependencies-arch.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-sudo pacman -S cmake extra-cmake-modules gcc
+sudo pacman -S cmake extra-cmake-modules gcc make


### PR DESCRIPTION
I've seen in several installations that the package (make) is missing, so it throws an error when trying to run the command
```make clean && \ make```